### PR TITLE
Modern hero panel login redesign

### DIFF
--- a/public/pages/login/index.html
+++ b/public/pages/login/index.html
@@ -8,23 +8,47 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400..800&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/SyPdN-WebApp/public/assets/css/base.css">
+  <link rel="stylesheet" href="./login.css">
 </head>
 
 <body>
   <nav id="appMenu"></nav>
 
-  <main class="container center-screen" id="main">
-    <section id="loginBox" class="card login-card fx-pop">
-      <h3>Ingresar</h3>
-      <form id="loginForm">
-        <label>Usuario<br><input id="username" class="input" required></label><br>
-        <label>Contraseña<br><input id="password" class="input" type="password" required></label>
-        <div class="login-actions">
-          <button type="submit" class="btn btn-primary">Entrar</button>
-        </div>
-      </form>
-      <div id="loginMsg" style="color:#c00;margin-top:.5rem"></div>
-    </section>
+  <main class="login-hero">
+    <div class="login-hero-panel">
+      <div class="login-info">
+        <h1>Sistemas y Procesos de Negocios</h1>
+        <h2>Plataforma de gestión unificada</h2>
+        <p>Accedé con tu cuenta para continuar.</p>
+      </div>
+      <div class="login-form-wrap">
+        <section class="card login-card">
+          <h3>INGRESAR</h3>
+          <form id="loginForm">
+            <div class="field">
+              <span class="field-icon">
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg>
+              </span>
+              <input id="username" class="input" required placeholder="Usuario">
+            </div>
+            <div class="field">
+              <span class="field-icon">
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="11" width="18" height="11" rx="2" ry="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg>
+              </span>
+              <input id="password" class="input" type="password" required placeholder="Contraseña">
+              <button type="button" id="showPass" class="show-btn" aria-label="Mostrar contraseña">Ver</button>
+            </div>
+            <div class="login-extra">
+              <label><input type="checkbox" id="remember"> Recordame</label>
+              <a href="#">Olvidé mi contraseña</a>
+            </div>
+            <button type="submit" class="btn btn-primary" style="width:100%">Ingresar</button>
+            <p class="account-link">¿No tenés cuenta? <a href="#">Solicitar cuenta</a></p>
+          </form>
+          <div id="loginMsg" style="color:#c00;margin-top:.5rem"></div>
+        </section>
+      </div>
+    </div>
   </main>
 
   <script src="/SyPdN-WebApp/public/assets/js/api.js"></script>
@@ -34,3 +58,4 @@
 </body>
 
 </html>
+

--- a/public/pages/login/login.css
+++ b/public/pages/login/login.css
@@ -1,0 +1,43 @@
+/* Login centering and animation overrides */
+.center-screen{min-height:calc(100vh - 68px);display:flex;align-items:center;justify-content:center;padding:2rem}
+.fx-pop{animation:pop-in .8s cubic-bezier(.2,.7,.3,1) both;transform-origin:center}
+@keyframes pop-in{0%{opacity:0;transform:scale(.9)}100%{opacity:1;transform:scale(1)}}
+.login-card h2{margin:0 0 .5rem 0;text-align:center;font-size:1.4rem}
+.login-card h3{margin:.25rem 0 1rem 0;text-align:center}
+.login-card .input{margin-top:.25rem}
+.login-actions{display:flex;gap:.6rem;justify-content:flex-end;margin-top:1rem}
+
+/* Login hero panel */
+.login-hero{display:flex;align-items:center;justify-content:center;padding:2rem;min-height:calc(100vh - 68px)}
+.login-hero-panel{width:100%;max-width:1100px;display:flex;border-radius:40px;overflow:hidden;position:relative;box-shadow:var(--shadow);background:linear-gradient(135deg,#ffa726,#fb8c00)}
+.login-hero-panel::before{content:"";position:absolute;inset:0;background:radial-gradient(circle at 25% 30%,rgba(255,255,255,.2)0,transparent55%),radial-gradient(circle at 80% 70%,rgba(255,255,255,.15)0,transparent50%)}
+.login-info{flex:1;padding:3rem 2.5rem;color:#fff;display:flex;flex-direction:column;justify-content:center}
+.login-info h1{margin:0 0 .5rem 0;font-size:2rem}
+.login-info h2{margin:0 0 1rem 0;font-weight:400;font-size:1.25rem}
+.login-info p{margin:0;font-size:1rem;max-width:28ch}
+.login-form-wrap{flex:1;display:flex;align-items:center;justify-content:center;padding:3rem 2.5rem}
+.login-card{width:100%;max-width:360px;padding:2rem}
+
+/* Inputs con ícono y botón mostrar */
+.field{position:relative;margin-top:1rem}
+.field:first-of-type{margin-top:0}
+.field-icon{position:absolute;left:.75rem;top:50%;transform:translateY(-50%);width:18px;height:18px;color:var(--muted)}
+.field input{padding-left:2.5rem;padding-right:3rem}
+.show-btn{position:absolute;right:.5rem;top:50%;transform:translateY(-50%);background:transparent;border:none;color:var(--primary);cursor:pointer;font-size:.85rem;padding:.25rem}
+.show-btn:active{opacity:.7}
+
+/* Extras del login */
+.login-extra{display:flex;justify-content:space-between;align-items:center;margin:.75rem 0 1rem;font-size:.9rem}
+.login-extra label{display:flex;align-items:center;gap:.35rem}
+.account-link{margin-top:1rem;text-align:center;font-size:.9rem}
+
+@media(max-width:760px){
+  .login-hero-panel{flex-direction:column}
+  .login-info{text-align:center}
+  .login-info p{margin-left:auto;margin-right:auto}
+  .login-form-wrap{padding-top:0}
+}
+
+@media (prefers-reduced-motion: reduce){
+  .fx-pop{animation:none;transition:none}
+}

--- a/public/pages/login/login.js
+++ b/public/pages/login/login.js
@@ -20,8 +20,18 @@ async function apiTryPost(path, body, opts){
 }
 
 (async function init(){
-  const loginForm = document.getElementById('loginForm');
-  const loginMsg = document.getElementById('loginMsg');
+    const loginForm = document.getElementById('loginForm');
+    const loginMsg = document.getElementById('loginMsg');
+    const password = document.getElementById('password');
+    const toggle = document.getElementById('showPass');
+
+    // Mostrar contraseña mientras se mantiene presionado
+    if (password && toggle) {
+      const hide = () => (password.type = 'password');
+      toggle.addEventListener('mousedown', () => (password.type = 'text'));
+      toggle.addEventListener('mouseup', hide);
+      toggle.addEventListener('mouseleave', hide);
+    }
 
   // Si ya hay token, ir al home
   if (api.getToken()) {


### PR DESCRIPTION
## Summary
- rework login into two-column hero panel with orange gradient and bubble background
- white branding copy on left and clean card on right with icon inputs and show-password button
- move login styles into dedicated login.css and restore base.css to prior state

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bf480338208322b9e746d02d20d250